### PR TITLE
YouTube task: get API key from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ https://TASK_URL/TASK_NAME/MEDIUM_USERNAME
 
 ---
 
-**`webtask-youtube.js`**: Generic task to fetch and reconstruct items from any YouTube account. For now, only fetches a playlist.
+**`webtask-youtube.js`**: Generic task to fetch and reconstruct items from any YouTube account. For now, only fetches a playlist. YouTube API key is provided via [secret environment variable](https://webtask.io/docs/issue_parameters) `YOUTUBE_API_KEY` setup in web editor of webtask.io
 
 Construct your request url like so, e.g. locally:
 
 ```
-http://localhost:8080/YOUTUBE_PLAYLIST_ID/YOUTUBE_API_KEY
+http://localhost:8080/YOUTUBE_PLAYLIST_ID
 ```
 
 Add the task name when published on webtask.io:
 
 ```
-https://TASK_URL/TASK_NAME/YOUTUBE_PLAYLIST_ID/YOUTUBE_API_KEY
+https://TASK_URL/TASK_NAME/YOUTUBE_PLAYLIST_ID
 ```
 
 ## Development

--- a/webtask-youtube.js
+++ b/webtask-youtube.js
@@ -10,9 +10,9 @@ app.get('/', (req, res) => {
     res.send('Please specify the playlist ID and API key.')
 })
 
-app.get('/:playlist/:apikey', (req, res) => {
+app.get('/:playlist', (req, res) => {
     const options = {
-        url: `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet%2CcontentDetails&playlistId=${req.params.playlist}&key=${req.params.apikey}`,
+        url: `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet%2CcontentDetails&playlistId=${req.params.playlist}&key=${req.webtaskContext.secrets.YOUTUBE_API_KEY}`,
         headers: { 'referer': req.headers.host }
     }
 
@@ -41,9 +41,9 @@ app.get('/:playlist/:apikey', (req, res) => {
     })
 })
 
-app.get('/:playlist/:apikey/raw', (req, res) => {
+app.get('/:playlist/raw', (req, res) => {
     const options = {
-        url: `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet%2CcontentDetails&playlistId=${req.params.playlist}&key=${req.params.apikey}`,
+        url: `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet%2CcontentDetails&playlistId=${req.params.playlist}&key=${process.env.YOUTUBE_API_KEY}`,
         headers: { 'referer': req.headers.host }
     }
 


### PR DESCRIPTION
Instead of receiving the api key as url parameter from the client, grab it from [secret environment variable](https://webtask.io/docs/issue_parameters) setup in web editor of webtask.io.