### PR TITLE
add videos querying by channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ For all endpoints, response is reconstructed in the same format:
 }]
 ```
 
+If you want to get the original response returned from YouTube API, append `/raw` at the end of your request, e.g.:
+
+```
+https://TASK_URL/TASK_NAME/playlist/:youtube_playlist_id/raw
+```
+
 ### Bounties
 
 **`webtask-bounties.js`**: Task to fetch open bounties on Gitcoin and Bounties.network in one request. Task creates a unified response from fetching both networks.

--- a/README.md
+++ b/README.md
@@ -43,15 +43,37 @@ https://TASK_URL/TASK_NAME/:medium_username
 
 ### YouTube
 
-**`webtask-youtube.js`**: Generic task to fetch and reconstruct items from any YouTube account. For now, only fetches a playlist. YouTube API key is provided via [secret environment variable](https://webtask.io/docs/issue_parameters) `YOUTUBE_API_KEY` setup in web editor of webtask.io.
+**`webtask-youtube.js`**: Generic task to fetch and reconstruct items from any YouTube account. YouTube API key is provided via [secret environment variable](https://webtask.io/docs/issue_parameters) `YOUTUBE_API_KEY` setup in web editor of webtask.io.
 
-Construct your request url like so, e.g. locally:
+* `/playlist/:playlistId`: returns all videos in the given playlist.
+* `/channel/:channelId`: returns latest 10 videos in the given channel, sorted by date.
+
+Construct your `GET` request urls like so:
 
 ```bash
-http://localhost:8080/:youtube_playlist_id
+http://localhost:8080/playlist/:youtube_playlist_id
+http://localhost:8080/channel/:youtube_channel_id
 
 # when published on webtask.io
-https://TASK_URL/TASK_NAME/:youtube_playlist_id
+https://TASK_URL/TASK_NAME/playlist/:youtube_playlist_id
+https://TASK_URL/TASK_NAME/channel/:youtube_channel_id
+```
+
+**Response**
+
+For all endpoints, response is reconstructed in the same format:
+
+```json
+[{
+    "id": "8EMowpNlWPE",
+    "title": "Fang Gong, Researcher - Bringing Privacy to Ocean Protocol",
+    "description": "At Ocean Protocol, we unlock data for AI and use TCRs to maintain a registry of high-quality data sets through voting. Privacy is essential to protecting the ...",
+    "imageUrl": "https://i.ytimg.com/vi/8EMowpNlWPE/mqdefault.jpg",
+    "videoUrl": "https://www.youtube.com/watch?v=8EMowpNlWPE"
+},
+{
+    ...
+}]
 ```
 
 ### Bounties

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "start": "wt serve webtask-bounties.js",
+        "start": "wt serve webtask-youtube.js",
         "test": "eslint ./*.js"
     },
     "dependencies": {

--- a/webtask-youtube.js
+++ b/webtask-youtube.js
@@ -20,7 +20,7 @@ const makeRequest = (options, cb) => {
 }
 
 app.get('/', (req, res) => {
-    res.send('Please specify the playlist ID as parameter.')
+    res.send('Please use /channel or /playlist endpoints, appended with the channel or playlist ID as parameter.')
 })
 
 app.get('/channel/:channelId', (req, res) => {
@@ -44,6 +44,17 @@ app.get('/channel/:channelId', (req, res) => {
         }
 
         res.send(parsedPosts)
+    })
+})
+
+app.get('/channel/:channelId/raw', (req, res) => {
+    const options = {
+        url: `https://www.googleapis.com/youtube/v3/search?part=snippet&channelId=${req.params.channelId}&maxResults=10&order=date&type=video&key=${req.webtaskContext.secrets.YOUTUBE_API_KEY}`,
+        headers: { 'referer': req.headers.host }
+    }
+
+    makeRequest(options, (videos) => {
+        res.send(videos)
     })
 })
 
@@ -73,18 +84,12 @@ app.get('/playlist/:playlistId', (req, res) => {
 
 app.get('/playlist/:playlist/raw', (req, res) => {
     const options = {
-        url: `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet%2CcontentDetails&playlistId=${req.params.playlist}&key=${process.env.YOUTUBE_API_KEY}`,
+        url: `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet%2CcontentDetails&maxResults=10&playlistId=${req.params.playlist}&key=${process.env.YOUTUBE_API_KEY}`,
         headers: { 'referer': req.headers.host }
     }
 
-    request(options, (error, response, body) => {
-        const json = JSON.parse(body)
-
-        if (error) {
-            return
-        }
-
-        res.send(json.items)
+    makeRequest(options, (videos) => {
+        res.send(videos)
     })
 })
 

--- a/webtask-youtube.js
+++ b/webtask-youtube.js
@@ -49,7 +49,7 @@ app.get('/channel/:channelId', (req, res) => {
 
 app.get('/playlist/:playlistId', (req, res) => {
     const options = {
-        url: `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet%2CcontentDetails&playlistId=${req.params.playlistID}&key=${req.webtaskContext.secrets.YOUTUBE_API_KEY}`,
+        url: `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet%2CcontentDetails&maxResults=10&playlistId=${req.params.playlistID}&key=${req.webtaskContext.secrets.YOUTUBE_API_KEY}`,
         headers: { 'referer': req.headers.host }
     }
 

--- a/webtask-youtube.js
+++ b/webtask-youtube.js
@@ -12,7 +12,11 @@ const makeRequest = (options, cb) => {
         const videos = json.items
 
         if (error) {
-            return
+            return cb(error)
+        }
+
+        if (json.error) {
+            return cb(json.error)
         }
 
         return cb(videos)
@@ -60,7 +64,7 @@ app.get('/channel/:channelId/raw', (req, res) => {
 
 app.get('/playlist/:playlistId', (req, res) => {
     const options = {
-        url: `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet%2CcontentDetails&maxResults=10&playlistId=${req.params.playlistID}&key=${req.webtaskContext.secrets.YOUTUBE_API_KEY}`,
+        url: `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet%2CcontentDetails&maxResults=10&playlistId=${req.params.playlistId}&key=${req.webtaskContext.secrets.YOUTUBE_API_KEY}`,
         headers: { 'referer': req.headers.host }
     }
 
@@ -82,9 +86,9 @@ app.get('/playlist/:playlistId', (req, res) => {
     })
 })
 
-app.get('/playlist/:playlist/raw', (req, res) => {
+app.get('/playlist/:playlistId/raw', (req, res) => {
     const options = {
-        url: `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet%2CcontentDetails&maxResults=10&playlistId=${req.params.playlist}&key=${process.env.YOUTUBE_API_KEY}`,
+        url: `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet%2CcontentDetails&maxResults=10&playlistId=${req.params.playlistId}&key=${req.webtaskContext.secrets.YOUTUBE_API_KEY}`,
         headers: { 'referer': req.headers.host }
     }
 


### PR DESCRIPTION
New endpoints for youtube task, adding ability to get videos by playlist, or channel.

* `/playlist/:playlistId`: returns all videos in the given playlist.
* `/channel/:channelId`: returns latest 10 videos in the given channel, sorted by date.